### PR TITLE
[PT-6701] upgrade tf and providers

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -17,6 +17,6 @@
 terraform {
   required_version = ">= 0.12"
   required_providers {
-    vault = "~> 2.11"
+    vault = ">= 2.11"
   }
 }


### PR DESCRIPTION
In order to upgrade cw-vault provider to the latest version, we need to remove this constraint 